### PR TITLE
Add invoices page

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/index.js
+++ b/app/javascript/dashboard/i18n/locale/en/index.js
@@ -21,6 +21,7 @@ import generalSettings from './generalSettings.json';
 import helpCenter from './helpCenter.json';
 import inbox from './inbox.json';
 import inboxMgmt from './inboxMgmt.json';
+import invoice from './invoice.json';
 import integrationApps from './integrationApps.json';
 import integrations from './integrations.json';
 import labelsMgmt from './labelsMgmt.json';
@@ -60,6 +61,7 @@ export default {
   ...helpCenter,
   ...inbox,
   ...inboxMgmt,
+  ...invoice,
   ...integrationApps,
   ...integrations,
   ...labelsMgmt,

--- a/app/javascript/dashboard/i18n/locale/en/invoice.json
+++ b/app/javascript/dashboard/i18n/locale/en/invoice.json
@@ -1,0 +1,19 @@
+{
+  "INVOICES_LAYOUT": {
+    "HEADER": {
+      "TITLE": "Invoices",
+      "SEARCH_TITLE": "Search invoices",
+      "SEARCH_PLACEHOLDER": "Search...",
+      "BREADCRUMB": {
+        "INVOICES": "Invoices"
+      }
+    },
+    "EMPTY_STATE": {
+      "TITLE": "No invoices found in this account",
+      "SUBTITLE": "Start adding new invoices by clicking on the button below",
+      "BUTTON_LABEL": "Add invoice",
+      "SEARCH_EMPTY_STATE_TITLE": "No invoices match your search \uD83D\uDD0D",
+      "LIST_EMPTY_STATE_TITLE": "No invoices available in this view \uD83D\uDCCB"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/locale/ko/index.js
+++ b/app/javascript/dashboard/i18n/locale/ko/index.js
@@ -21,6 +21,7 @@ import generalSettings from './generalSettings.json';
 import helpCenter from './helpCenter.json';
 import inbox from './inbox.json';
 import inboxMgmt from './inboxMgmt.json';
+import invoice from './invoice.json';
 import integrationApps from './integrationApps.json';
 import integrations from './integrations.json';
 import labelsMgmt from './labelsMgmt.json';
@@ -60,6 +61,7 @@ export default {
   ...helpCenter,
   ...inbox,
   ...inboxMgmt,
+  ...invoice,
   ...integrationApps,
   ...integrations,
   ...labelsMgmt,

--- a/app/javascript/dashboard/i18n/locale/ko/invoice.json
+++ b/app/javascript/dashboard/i18n/locale/ko/invoice.json
@@ -1,0 +1,19 @@
+{
+  "INVOICES_LAYOUT": {
+    "HEADER": {
+      "TITLE": "Invoices",
+      "SEARCH_TITLE": "Search invoices",
+      "SEARCH_PLACEHOLDER": "Search...",
+      "BREADCRUMB": {
+        "INVOICES": "Invoices"
+      }
+    },
+    "EMPTY_STATE": {
+      "TITLE": "No invoices found in this account",
+      "SUBTITLE": "Start adding new invoices by clicking on the button below",
+      "BUTTON_LABEL": "Add invoice",
+      "SEARCH_EMPTY_STATE_TITLE": "No invoices match your search \uD83D\uDD0D",
+      "LIST_EMPTY_STATE_TITLE": "No invoices available in this view \uD83D\uDCCB"
+    }
+  }
+}

--- a/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
+++ b/app/javascript/dashboard/routes/dashboard/dashboard.routes.js
@@ -2,6 +2,7 @@ import settings from './settings/settings.routes';
 import conversation from './conversation/conversation.routes';
 import { routes as searchRoutes } from '../../modules/search/search.routes';
 import { routes as contactRoutes } from './contacts/routes';
+import { routes as invoiceRoutes } from './invoices/routes';
 import { routes as notificationRoutes } from './notifications/routes';
 import { routes as inboxRoutes } from './inbox/routes';
 import { frontendURL } from '../../helper/URLHelper';
@@ -21,6 +22,7 @@ export default {
         ...inboxRoutes,
         ...conversation.routes,
         ...settings.routes,
+        ...invoiceRoutes,
         ...contactRoutes,
         ...searchRoutes,
         ...notificationRoutes,

--- a/app/javascript/dashboard/routes/dashboard/invoices/pages/InvoicesIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/invoices/pages/InvoicesIndex.vue
@@ -1,0 +1,169 @@
+<script setup>
+import { onMounted, ref, computed, reactive, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useStore, useMapGetter } from 'dashboard/composables/store';
+import { debounce } from '@chatwoot/utils';
+import { useUISettings } from 'dashboard/composables/useUISettings';
+
+import ContactsListLayout from 'dashboard/components-next/Contacts/ContactsListLayout.vue';
+import ContactsList from 'dashboard/components-next/Contacts/Pages/ContactsList.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+
+const DEFAULT_SORT_FIELD = 'created_at';
+const DEBOUNCE_DELAY = 300;
+
+const store = useStore();
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+
+const { updateUISettings, uiSettings } = useUISettings();
+
+const invoices = useMapGetter('invoices/getInvoicesList');
+const uiFlags = useMapGetter('invoices/getUIFlags');
+const meta = useMapGetter('invoices/getMeta');
+
+const searchQuery = computed(() => route.query?.search);
+const searchValue = ref(searchQuery.value || '');
+const pageNumber = computed(() => Number(route.query?.page) || 1);
+
+const parseSortSettings = (sortString = '') => {
+  const hasDescending = sortString.startsWith('-');
+  const sortField = hasDescending ? sortString.slice(1) : sortString;
+  return {
+    sort: sortField || DEFAULT_SORT_FIELD,
+    order: hasDescending ? '-' : '',
+  };
+};
+
+const { invoices_sort_by: invoicesSortBy = '' } = uiSettings.value ?? {};
+const { sort: initialSort, order: initialOrder } = parseSortSettings(invoicesSortBy);
+
+const sortState = reactive({
+  activeSort: initialSort,
+  activeOrdering: initialOrder,
+});
+
+const isFetchingList = computed(() => uiFlags.value.isFetching);
+const currentPage = computed(() => Number(meta.value?.currentPage));
+const totalItems = computed(() => meta.value?.count);
+const hasInvoices = computed(() => invoices.value.length > 0);
+
+const headerTitle = computed(() =>
+  searchQuery.value
+    ? t('INVOICES_LAYOUT.HEADER.SEARCH_TITLE')
+    : t('INVOICES_LAYOUT.HEADER.TITLE')
+);
+
+const updatePageParam = (page, search = '') => {
+  const query = {
+    ...route.query,
+    page: page.toString(),
+    ...(search ? { search } : {}),
+  };
+
+  if (!search) {
+    delete query.search;
+  }
+
+  router.replace({ query });
+};
+
+const buildSortAttr = () => `${sortState.activeOrdering}${sortState.activeSort}`;
+
+const fetchInvoices = async (page = 1) => {
+  await store.dispatch('invoices/get', { page, sortAttr: buildSortAttr() });
+  updatePageParam(page);
+};
+
+const searchInvoices = debounce(async (value, page = 1) => {
+  searchValue.value = value;
+
+  if (!value) {
+    updatePageParam(page);
+    await fetchInvoices(page);
+    return;
+  }
+
+  updatePageParam(page, value);
+  await store.dispatch('invoices/search', {
+    page,
+    sortAttr: buildSortAttr(),
+    search: encodeURIComponent(value),
+  });
+}, DEBOUNCE_DELAY);
+
+const handleSort = async ({ sort, order }) => {
+  Object.assign(sortState, { activeSort: sort, activeOrdering: order });
+
+  await updateUISettings({ invoices_sort_by: buildSortAttr() });
+
+  if (searchQuery.value) {
+    await searchInvoices(searchValue.value);
+    return;
+  }
+
+  await fetchInvoices();
+};
+
+watch(searchQuery, value => {
+  if (isFetchingList.value) return;
+  searchValue.value = value || '';
+  if (value === undefined) {
+    fetchInvoices();
+  }
+});
+
+onMounted(async () => {
+  if (searchQuery.value) {
+    await searchInvoices(searchQuery.value, pageNumber.value);
+    return;
+  }
+  await fetchInvoices(pageNumber.value);
+});
+</script>
+
+<template>
+  <div
+    class="flex flex-col justify-between flex-1 h-full m-0 overflow-auto bg-n-background"
+  >
+    <ContactsListLayout
+      :search-value="searchValue"
+      :header-title="headerTitle"
+      :current-page="currentPage"
+      :total-items="totalItems"
+      :show-pagination-footer="!isFetchingList && hasInvoices"
+      :active-sort="sortState.activeSort"
+      :active-ordering="sortState.activeOrdering"
+      :is-fetching-list="isFetchingList"
+      @update:current-page="fetchInvoices"
+      @search="searchInvoices"
+      @update:sort="handleSort"
+    >
+      <div
+        v-if="isFetchingList"
+        class="flex items-center justify-center py-10 text-n-slate-11"
+      >
+        <Spinner />
+      </div>
+
+      <template v-else>
+        <div
+          v-if="!hasInvoices"
+          class="flex items-center justify-center py-10"
+        >
+          <span class="text-base text-n-slate-11">
+            {{
+              searchQuery
+                ? t('INVOICES_LAYOUT.EMPTY_STATE.SEARCH_EMPTY_STATE_TITLE')
+                : t('INVOICES_LAYOUT.EMPTY_STATE.LIST_EMPTY_STATE_TITLE')
+            }}
+          </span>
+        </div>
+
+        <ContactsList v-else :contacts="invoices" />
+      </template>
+    </ContactsListLayout>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/invoices/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/invoices/routes.js
@@ -1,0 +1,22 @@
+import { frontendURL } from '../../../helper/URLHelper';
+import InvoicesIndex from './pages/InvoicesIndex.vue';
+
+const commonMeta = {
+  permissions: ['administrator', 'agent'],
+};
+
+export const routes = [
+  {
+    path: frontendURL('accounts/:accountId/invoices'),
+    component: InvoicesIndex,
+    meta: commonMeta,
+    children: [
+      {
+        path: '',
+        name: 'invoices_dashboard_index',
+        component: InvoicesIndex,
+        meta: commonMeta,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add routes for invoices dashboard page
- create InvoicesIndex.vue using existing Contacts components
- include invoice routes in dashboard router
- add invoice translation strings and load them in i18n

## Testing
- `npx eslint -c .eslintrc.js app/javascript/dashboard/routes/dashboard/invoices/routes.js app/javascript/dashboard/routes/dashboard/invoices/pages/InvoicesIndex.vue app/javascript/dashboard/routes/dashboard/dashboard.routes.js app/javascript/dashboard/i18n/locale/en/invoice.json app/javascript/dashboard/i18n/locale/en/index.js app/javascript/dashboard/i18n/locale/ko/invoice.json app/javascript/dashboard/i18n/locale/ko/index.js` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_685b6d635b388330ab61aad0dcb52064