### PR TITLE
Add Invoices sidebar entry

### DIFF
--- a/app/javascript/dashboard/components/layout/config/sidebarItems/settings.js
+++ b/app/javascript/dashboard/components/layout/config/sidebarItems/settings.js
@@ -10,6 +10,7 @@ const settings = accountId => ({
     'automation_list',
     'auditlogs_list',
     'billing_settings_index',
+    'invoices_dashboard_index',
     'canned_list',
     'general_settings_index',
     'general_settings',
@@ -213,6 +214,16 @@ const settings = accountId => ({
       toState: frontendURL(`accounts/${accountId}/settings/billing`),
       toStateName: 'billing_settings_index',
       showOnlyOnCloud: true,
+    },
+    {
+      icon: 'document-outline',
+      label: 'INVOICES',
+      hasSubMenu: false,
+      meta: {
+        permissions: ['administrator', 'agent'],
+      },
+      toState: frontendURL(`accounts/${accountId}/invoices`),
+      toStateName: 'invoices_dashboard_index',
     },
   ],
 });


### PR DESCRIPTION
## Summary
- expose invoice index route in Settings sidebar

## Testing
- `pnpm --version` *(fails: Proxy response (403) when HTTP tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_685b7188bb6883309408eb18ecbb5ae4