### PR TITLE
Add invoices API

### DIFF
--- a/app/controllers/api/v1/accounts/invoices_controller.rb
+++ b/app/controllers/api/v1/accounts/invoices_controller.rb
@@ -1,0 +1,34 @@
+class Api::V1::Accounts::InvoicesController < Api::V1::Accounts::BaseController
+  before_action :invoice, except: [:index, :create]
+
+  def index
+    @invoices = Current.account.invoices
+  end
+
+  def show; end
+
+  def create
+    @invoice = Current.account.invoices.create!(permitted_params)
+  end
+
+  def update
+    @invoice.update!(permitted_params)
+  end
+
+  def destroy
+    @invoice.destroy!
+    head :ok
+  end
+
+  private
+
+  def invoice
+    @invoice ||= Current.account.invoices.find(params[:id])
+  end
+
+  def permitted_params
+    params.require(:invoice).permit(:number, :total, :status, additional_attributes: {})
+  end
+end
+
+Api::V1::Accounts::InvoicesController.prepend_mod_with('Api::V1::Accounts::InvoicesController')

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,6 +52,7 @@ class Account < ApplicationRecord
   has_many :custom_attribute_definitions, dependent: :destroy_async
   has_many :custom_filters, dependent: :destroy_async
   has_many :dashboard_apps, dependent: :destroy_async
+  has_many :invoices, dependent: :destroy_async
   has_many :data_imports, dependent: :destroy_async
   has_many :email_channels, dependent: :destroy_async, class_name: '::Channel::Email'
   has_many :facebook_pages, dependent: :destroy_async, class_name: '::Channel::FacebookPage'

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,0 +1,13 @@
+class Invoice < ApplicationRecord
+  belongs_to :account
+
+  before_validation :set_default_additional_attributes
+
+  private
+
+  def set_default_additional_attributes
+    self.additional_attributes = {} unless additional_attributes.is_a?(Hash)
+  end
+end
+
+Invoice.prepend_mod_with('Invoice')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
           resources :custom_roles, only: [:index, :create, :show, :update, :destroy]
           resources :campaigns, only: [:index, :create, :show, :update, :destroy]
           resources :dashboard_apps, only: [:index, :show, :create, :update, :destroy]
+          resources :invoices
           namespace :channels do
             resource :twilio_channel, only: [:create]
           end

--- a/db/migrate/20250418123456_create_invoices.rb
+++ b/db/migrate/20250418123456_create_invoices.rb
@@ -1,0 +1,15 @@
+class CreateInvoices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :invoices do |t|
+      t.references :account, null: false
+      t.string :number
+      t.decimal :total
+      t.string :status
+      t.jsonb :additional_attributes
+
+      t.timestamps
+    end
+
+    add_index :invoices, :account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_16_182131) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_18_123456) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1072,6 +1072,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_16_182131) do
     t.boolean "open_all_day", default: false
     t.index ["account_id"], name: "index_working_hours_on_account_id"
     t.index ["inbox_id"], name: "index_working_hours_on_inbox_id"
+  end
+
+  create_table "invoices", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "number"
+    t.decimal "total"
+    t.string "status"
+    t.jsonb "additional_attributes"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["account_id"], name: "index_invoices_on_account_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## Summary
- add invoices table
- add invoice model with default `additional_attributes`
- expose invoices API under account scope
- support invoice routes

## Testing
- `bundle exec rspec` *(fails: rbenv: version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b8192e000833099c4a16457886336