### PR TITLE
Add invoices menu to next sidebar

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
+++ b/app/javascript/dashboard/components-next/sidebar/Sidebar.vue
@@ -469,6 +469,12 @@ const menuItems = computed(() => {
           icon: 'i-lucide-credit-card',
           to: accountScopedRoute('billing_settings_index'),
         },
+        {
+          name: 'Settings Invoices',
+          label: t('SIDEBAR.INVOICES'),
+          icon: 'i-lucide-file-text',
+          to: accountScopedRoute('invoices_dashboard_index'),
+        },
       ],
     },
   ];

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -301,6 +301,7 @@
     "MACROS": "Macros",
     "TEAMS": "Teams",
     "BILLING": "Billing",
+    "INVOICES": "Invoices",
     "CUSTOM_VIEWS_FOLDER": "Folders",
     "CUSTOM_VIEWS_SEGMENTS": "Segments",
     "ALL_CONTACTS": "All Contacts",

--- a/app/javascript/dashboard/i18n/locale/ko/settings.json
+++ b/app/javascript/dashboard/i18n/locale/ko/settings.json
@@ -301,6 +301,7 @@
     "MACROS": "매크로",
     "TEAMS": "팀",
     "BILLING": "청구",
+    "INVOICES": "인보이스",
     "CUSTOM_VIEWS_FOLDER": "폴더",
     "CUSTOM_VIEWS_SEGMENTS": "세그먼트",
     "ALL_CONTACTS": "모든 연락처",


### PR DESCRIPTION
## Summary
- expose invoices dashboard route in the new sidebar
- provide Korean and English sidebar translations

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b81d11f488330b03bcce6911d60a0