### PR TITLE
Add invoices sidebar item

### DIFF
--- a/app/javascript/dashboard/components/layout/config/default-sidebar.js
+++ b/app/javascript/dashboard/components/layout/config/default-sidebar.js
@@ -2,6 +2,7 @@ import conversations from './sidebarItems/conversations';
 import contacts from './sidebarItems/contacts';
 import reports from './sidebarItems/reports';
 import campaigns from './sidebarItems/campaigns';
+import invoices from './sidebarItems/invoices';
 import settings from './sidebarItems/settings';
 import notifications from './sidebarItems/notifications';
 import primaryMenu from './sidebarItems/primaryMenu';
@@ -13,6 +14,7 @@ export const getSidebarItems = accountId => ({
     contacts(accountId),
     reports(accountId),
     campaigns(accountId),
+    invoices(accountId),
     settings(accountId),
     notifications(accountId),
   ],

--- a/app/javascript/dashboard/components/layout/config/sidebarItems/invoices.js
+++ b/app/javascript/dashboard/components/layout/config/sidebarItems/invoices.js
@@ -1,0 +1,17 @@
+import { frontendURL } from '../../../../helper/URLHelper';
+
+const invoices = accountId => ({
+  parentNav: 'invoices',
+  routes: ['invoices_dashboard_index'],
+  menuItems: [
+    {
+      icon: 'document-outline',
+      label: 'INVOICES',
+      hasSubMenu: false,
+      toState: frontendURL(`accounts/${accountId}/invoices`),
+      toStateName: 'invoices_dashboard_index',
+    },
+  ],
+});
+
+export default invoices;

--- a/app/javascript/dashboard/components/layout/config/sidebarItems/primaryMenu.js
+++ b/app/javascript/dashboard/components/layout/config/sidebarItems/primaryMenu.js
@@ -50,6 +50,13 @@ const primaryMenuItems = accountId => [
     toStateName: 'campaigns_ongoing_index',
   },
   {
+    icon: 'document-outline',
+    key: 'invoices',
+    label: 'INVOICES',
+    toState: frontendURL(`accounts/${accountId}/invoices`),
+    toStateName: 'invoices_dashboard_index',
+  },
+  {
     icon: 'library',
     key: 'helpcenter',
     label: 'HELP_CENTER.TITLE',

--- a/app/javascript/dashboard/components/layout/config/sidebarItems/settings.js
+++ b/app/javascript/dashboard/components/layout/config/sidebarItems/settings.js
@@ -10,7 +10,6 @@ const settings = accountId => ({
     'automation_list',
     'auditlogs_list',
     'billing_settings_index',
-    'invoices_dashboard_index',
     'canned_list',
     'general_settings_index',
     'general_settings',
@@ -214,16 +213,6 @@ const settings = accountId => ({
       toState: frontendURL(`accounts/${accountId}/settings/billing`),
       toStateName: 'billing_settings_index',
       showOnlyOnCloud: true,
-    },
-    {
-      icon: 'document-outline',
-      label: 'INVOICES',
-      hasSubMenu: false,
-      meta: {
-        permissions: ['administrator', 'agent'],
-      },
-      toState: frontendURL(`accounts/${accountId}/invoices`),
-      toStateName: 'invoices_dashboard_index',
     },
   ],
 });


### PR DESCRIPTION
## Summary
- add invoices sidebar config
- expose invoices on primary menu
- import invoices in default sidebar and update menu order
- remove invoices entry from settings menu

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cade78f008330bda03e504bd51391