### PR TITLE
Search invoices across sheets

### DIFF
--- a/app/javascript/dashboard/components-next/Invoices/Pages/InvoicesList.vue
+++ b/app/javascript/dashboard/components-next/Invoices/Pages/InvoicesList.vue
@@ -3,7 +3,10 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import InvoiceCard from 'dashboard/components-next/Invoices/InvoiceCard.vue';
 
-const props = defineProps({ invoices: { type: Array, required: true } });
+const props = defineProps({
+  invoices: { type: Array, required: true },
+  allInvoices: { type: Array, default: () => [] },
+});
 const { t } = useI18n();
 
 const expandedCardId = ref(null);
@@ -19,8 +22,10 @@ const filteredInvoices = computed(() => {
   }
 
   const query = searchQuery.value.toLowerCase().trim();
+  const invoicesToFilter =
+    props.allInvoices.length > 0 ? props.allInvoices : props.invoices;
 
-  return props.invoices.filter(invoice => {
+  return invoicesToFilter.filter(invoice => {
     // 제목에서 검색
     if (invoice.title && invoice.title.toLowerCase().includes(query)) {
       return true;

--- a/app/javascript/dashboard/routes/dashboard/invoices/pages/InvoicesIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/invoices/pages/InvoicesIndex.vue
@@ -53,6 +53,9 @@ const showSidebar = computed(() => excelInvoices.value.length > 0);
 const selectedInvoice = computed(
   () => excelInvoices.value[selectedSheetIndex.value] || null
 );
+const allSheetInvoices = computed(() =>
+  excelInvoices.value.flatMap(sheet => sheet.invoices)
+);
 
 const isFetchingList = computed(() => uiFlags.value.isFetching);
 const currentPage = computed(() => Number(meta.value?.currentPage));
@@ -267,10 +270,11 @@ const selectSheet = index => {
 
           <!-- 오른쪽 메인 콘텐츠 - 선택된 시트 정보 -->
           <div class="flex-1 overflow-auto">
-            <InvoicesList
-              v-if="selectedInvoice && selectedInvoice.invoices"
-              :invoices="selectedInvoice.invoices"
-            />
+          <InvoicesList
+            v-if="selectedInvoice && selectedInvoice.invoices"
+            :invoices="selectedInvoice.invoices"
+            :all-invoices="allSheetInvoices"
+          />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow `InvoicesList` to filter on an optional `allInvoices` prop
- expose all worksheets' invoices from `InvoicesIndex` and pass them to `InvoicesList`

## Testing
- `pnpm run test:coverage` *(fails: Request was cancelled)*
- `bundle exec rspec` *(fails: version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b2f9e47dc8330ab30e06940b6521f